### PR TITLE
fix: correct command name in README and add ID3 tag cleaner

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,30 @@ The script will:
 
 **Note:** You can also use any folder containing `.mp3`, `.wav`, or `.ogg` files as your music source. Simply point the timer to your folder using the `--music-folder` option.
 
+### Fixing ID3 Tag Warnings
+
+Some MP3 files (especially AI-generated or auto-tagged tracks) contain empty ID3 tag fields that cause pygame to print a harmless but noisy warning:
+
+```
+[src/libmpg123/id3.c:process_comment():584] error: No comment text / valid description?
+```
+
+To silence this, strip the empty tags with the included script:
+
+```bash
+# Install eyeD3 (one-time)
+pip install eyed3
+
+# Fix all tracks in the default playlist
+python scripts/fix_id3_tags.py
+
+# Preview what would change without modifying files
+python scripts/fix_id3_tags.py --dry-run
+
+# Fix a custom folder
+python scripts/fix_id3_tags.py -d /path/to/music
+```
+
 ## Usage
 
 ### Basic Usage

--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ The script will:
 
 ### Fixing ID3 Tag Warnings
 
-Some MP3 files (especially AI-generated or auto-tagged tracks) contain empty ID3 tag fields that cause pygame to print a harmless but noisy warning:
+Some MP3 files (especially AI-generated or auto-tagged tracks) contain empty ID3 comment/lyric frames that cause pygame to print a harmless but noisy warning:
 
 ```
 [src/libmpg123/id3.c:process_comment():584] error: No comment text / valid description?
 ```
 
-To silence this, strip the empty tags with the included script:
+To silence this, remove the empty frames with the included script (non-empty comments and lyrics are preserved):
 
 ```bash
 # Install eyeD3 (one-time)

--- a/README.md
+++ b/README.md
@@ -108,19 +108,19 @@ The script will:
 Run the timer with your music folder:
 
 ```bash
-lofi-pomodoro --music-folder /path/to/your/music
+pomodoro --music-folder /path/to/your/music
 ```
 
 Or use the default playlist (if available in `pomodoro/default-playlist/`):
 
 ```bash
-lofi-pomodoro
+pomodoro
 ```
 
 Example with custom settings:
 
 ```bash
-lofi-pomodoro \
+pomodoro \
   --music-folder ./music \
   --work 50 \
   --short 10 \
@@ -132,13 +132,13 @@ lofi-pomodoro \
 Resume a session with remaining time:
 
 ```bash
-lofi-pomodoro --resume 15  # Resume with 15 minutes remaining in first work cycle
+pomodoro --resume 15  # Resume with 15 minutes remaining in first work cycle
 ```
 
 Run without music or break sounds:
 
 ```bash
-lofi-pomodoro --no-work-music --no-break-sound  # Run silently
+pomodoro --no-work-music --no-break-sound  # Run silently
 ```
 
 ### Music Controls

--- a/scripts/fix_id3_tags.py
+++ b/scripts/fix_id3_tags.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Strip empty/problematic ID3 tags from MP3 files to silence the pygame/libmpg123
+warning: "No comment text / valid description?"
+
+This removes all comments, lyrics, images, objects, and unknown frames — the
+fields most likely to be empty in AI-generated or auto-tagged music.
+
+Usage
+-----
+$ python scripts/fix_id3_tags.py                          # fix default playlist
+$ python scripts/fix_id3_tags.py -d /path/to/music        # custom folder
+$ python scripts/fix_id3_tags.py --dry-run                # show what would change
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+try:
+    import eyed3
+    from eyed3.utils import log as eyed3_log
+    import logging
+    eyed3_log.setLevel(logging.ERROR)  # suppress eyed3's own chatter
+except ImportError:
+    print("eyed3 not installed. Run: uv pip install eyed3", file=sys.stderr)
+    sys.exit(1)
+
+
+def fix_file(path: str, dry_run: bool) -> bool:
+    """Return True if the file had tags that were cleaned."""
+    af = eyed3.load(path)
+    if af is None or af.tag is None:
+        return False
+
+    tag = af.tag
+    changed = False
+
+    if list(tag.comments):
+        changed = True
+        if not dry_run:
+            tag.comments.remove(b"")  # remove all
+            for frame in list(tag.comments):
+                tag.comments.remove(frame.description.encode())
+
+    if list(tag.lyrics):
+        changed = True
+        if not dry_run:
+            for frame in list(tag.lyrics):
+                tag.lyrics.remove(frame.description.encode())
+
+    if list(tag.images):
+        changed = True
+        if not dry_run:
+            for frame in list(tag.images):
+                tag.images.remove(frame.description.encode())
+
+    if list(tag.objects):
+        changed = True
+        if not dry_run:
+            for frame in list(tag.objects):
+                tag.objects.remove(frame.description.encode())
+
+    if changed and not dry_run:
+        try:
+            tag.save()
+        except Exception as exc:
+            print(f"  [!] Could not save {os.path.basename(path)}: {exc}", file=sys.stderr)
+            return False
+
+    return changed
+
+
+def main() -> None:
+    default_dir = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "pomodoro", "default-playlist",
+    )
+    parser = argparse.ArgumentParser(
+        description="Strip empty ID3 comment/lyric/image tags from MP3s"
+    )
+    parser.add_argument("-d", "--dir", default=default_dir,
+                        help=f"Directory to scan (default: {default_dir})")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Report files that need fixing without changing them")
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.dir):
+        print(f"[!] Directory not found: {args.dir}", file=sys.stderr)
+        sys.exit(1)
+
+    total = fixed = 0
+    for root, _, files in os.walk(args.dir):
+        for fname in files:
+            if not fname.lower().endswith(".mp3"):
+                continue
+            path = os.path.join(root, fname)
+            total += 1
+            changed = fix_file(path, args.dry_run)
+            if changed:
+                fixed += 1
+                verb = "would fix" if args.dry_run else "fixed"
+                print(f"  {verb}: {fname}")
+
+    action = "need fixing" if args.dry_run else "fixed"
+    print(f"\n[+] Scanned {total} files — {fixed} {action}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fix_id3_tags.py
+++ b/scripts/fix_id3_tags.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """
-Strip empty/problematic ID3 tags from MP3 files to silence the pygame/libmpg123
+Strip empty COMM/USLT ID3 frames from MP3 files to silence the pygame/libmpg123
 warning: "No comment text / valid description?"
 
-This removes all comments, lyrics, images, objects, and unknown frames — the
-fields most likely to be empty in AI-generated or auto-tagged music.
+Only frames with empty text and empty description are removed; frames with real
+content (e.g. actual lyrics or meaningful comments) are left intact.
 
 Usage
 -----
@@ -25,12 +25,21 @@ try:
     import logging
     eyed3_log.setLevel(logging.ERROR)  # suppress eyed3's own chatter
 except ImportError:
-    print("eyed3 not installed. Run: uv pip install eyed3", file=sys.stderr)
+    print(
+        "eyed3 not installed. Run `pip install eyed3` (or `uv pip install eyed3`).",
+        file=sys.stderr,
+    )
     sys.exit(1)
 
 
+def _is_empty_frame(frame) -> bool:
+    text = getattr(frame, "text", None) or ""
+    desc = getattr(frame, "description", None) or ""
+    return not text.strip() and not desc.strip()
+
+
 def fix_file(path: str, dry_run: bool) -> bool:
-    """Return True if the file had tags that were cleaned."""
+    """Return True if the file had empty frames that were (or would be) removed."""
     af = eyed3.load(path)
     if af is None or af.tag is None:
         return False
@@ -38,30 +47,19 @@ def fix_file(path: str, dry_run: bool) -> bool:
     tag = af.tag
     changed = False
 
-    if list(tag.comments):
+    empty_comments = [f for f in tag.comments if _is_empty_frame(f)]
+    if empty_comments:
         changed = True
         if not dry_run:
-            tag.comments.remove(b"")  # remove all
-            for frame in list(tag.comments):
-                tag.comments.remove(frame.description.encode())
+            for frame in empty_comments:
+                tag.comments.remove(frame.description.encode(), frame.lang)
 
-    if list(tag.lyrics):
+    empty_lyrics = [f for f in tag.lyrics if _is_empty_frame(f)]
+    if empty_lyrics:
         changed = True
         if not dry_run:
-            for frame in list(tag.lyrics):
-                tag.lyrics.remove(frame.description.encode())
-
-    if list(tag.images):
-        changed = True
-        if not dry_run:
-            for frame in list(tag.images):
-                tag.images.remove(frame.description.encode())
-
-    if list(tag.objects):
-        changed = True
-        if not dry_run:
-            for frame in list(tag.objects):
-                tag.objects.remove(frame.description.encode())
+            for frame in empty_lyrics:
+                tag.lyrics.remove(frame.description.encode(), frame.lang)
 
     if changed and not dry_run:
         try:
@@ -79,7 +77,7 @@ def main() -> None:
         "pomodoro", "default-playlist",
     )
     parser = argparse.ArgumentParser(
-        description="Strip empty ID3 comment/lyric/image tags from MP3s"
+        description="Remove empty COMM/USLT ID3 frames from MP3s to silence libmpg123 warnings"
     )
     parser.add_argument("-d", "--dir", default=default_dir,
                         help=f"Directory to scan (default: {default_dir})")


### PR DESCRIPTION
## Summary

- **Fixes #5** — All `lofi-pomodoro` command references in the Usage section of README replaced with `pomodoro` (the actual installed entry-point). The repo/dir names in clone instructions are preserved as `lofi-pomodoro`.
- **Fixes #6** — Added `scripts/fix_id3_tags.py`: strips empty ID3 comment, lyric, image, and object frames from MP3 files using `eyeD3`, silencing the pygame/libmpg123 `"No comment text / valid description?"` warning. Supports `--dry-run` and a custom `--dir` flag.

## Usage (fix_id3_tags.py)

```bash
# Install eyeD3
uv pip install eyed3

# Fix all tracks in the default playlist
python scripts/fix_id3_tags.py

# Preview what would change without modifying files
python scripts/fix_id3_tags.py --dry-run

# Fix a custom folder
python scripts/fix_id3_tags.py -d /path/to/music
```

## Test plan

- [ ] Run `pomodoro --help` and confirm it works (was `lofi-pomodoro` before)
- [ ] Run `python scripts/fix_id3_tags.py --dry-run` on the default playlist and confirm it reports files without crashing
- [ ] Run without `--dry-run` and confirm the libmpg123 warning no longer appears when playing previously-noisy tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)