### PR TITLE
feat: download YouTube audio into the playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ To install all optional dependencies at once:
 uv pip install -e ".[scripts]"
 ```
 
+See [docs/scripts.md](docs/scripts.md) for the full CLI reference for each script.
+
 ### Downloading Free Music
 
 The project includes scripts to build your playlist from free sources.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Clone the repository and install locally:
 ```bash
 git clone https://github.com/WittmannF/lofi-pomodoro.git
 cd lofi-pomodoro
-pip install -e .
+uv venv .venv && source .venv/bin/activate
+uv pip install -e .
 ```
 
 ## Getting Started
@@ -82,15 +83,15 @@ The helper scripts each have their own dependencies beyond the core timer. Insta
 
 | Script | Purpose | Install |
 |--------|---------|---------|
-| `scripts/scrape_songs.py` | Download lo-fi tracks from Chosic | `pip install -e ".[scrape]"` |
-| `scripts/scrape_fma.py` | Download tracks from Free Music Archive | `pip install -e ".[scrape]"` |
-| `scripts/download_youtube.py` | Download audio from YouTube | `pip install -e ".[youtube]"` + `brew install ffmpeg` |
-| `scripts/fix_id3_tags.py` | Strip empty ID3 frames to silence pygame warnings | `pip install -e ".[id3]"` |
+| `scripts/scrape_songs.py` | Download lo-fi tracks from Chosic | `uv pip install -e ".[scrape]"` |
+| `scripts/scrape_fma.py` | Download tracks from Free Music Archive | `uv pip install -e ".[scrape]"` |
+| `scripts/download_youtube.py` | Download audio from YouTube | `uv pip install -e ".[youtube]"` + `brew install ffmpeg` |
+| `scripts/fix_id3_tags.py` | Strip empty ID3 frames to silence pygame warnings | `uv pip install -e ".[id3]"` |
 
 To install all optional dependencies at once:
 
 ```bash
-pip install -e ".[scripts]"
+uv pip install -e ".[scripts]"
 ```
 
 ### Downloading Free Music
@@ -126,19 +127,19 @@ All scripts save tracks directly to `pomodoro/default-playlist/` and remember wh
 Run the timer with your music folder:
 
 ```bash
-lofi-pomodoro --music-folder /path/to/your/music
+pomodoro --music-folder /path/to/your/music
 ```
 
 Or use the default playlist (if available in `pomodoro/default-playlist/`):
 
 ```bash
-lofi-pomodoro
+pomodoro
 ```
 
 Example with custom settings:
 
 ```bash
-lofi-pomodoro \
+pomodoro \
   --music-folder ./music \
   --work 50 \
   --short 10 \
@@ -150,13 +151,13 @@ lofi-pomodoro \
 Resume a session with remaining time:
 
 ```bash
-lofi-pomodoro --resume 15  # Resume with 15 minutes remaining in first work cycle
+pomodoro --resume 15  # Resume with 15 minutes remaining in first work cycle
 ```
 
 Run without music or break sounds:
 
 ```bash
-lofi-pomodoro --no-work-music --no-break-sound  # Run silently
+pomodoro --no-work-music --no-break-sound  # Run silently
 ```
 
 ### Music Controls
@@ -193,26 +194,21 @@ During work sessions, you can control the music playback:
    cd lofi-pomodoro
    ```
 
-2. Install dependencies:
+2. Create a virtual environment and install:
 
    ```bash
-   pip install -r requirements.txt
+   uv venv .venv && source .venv/bin/activate
+   uv pip install -e .
    ```
 
-3. Install the package in editable mode:
-
-   ```bash
-   pip install -e .
-   ```
-
-4. Try it out:
+3. Try it out:
 
    ```bash
    # Download some music first
    python scripts/scrape_songs.py
 
    # Run the timer
-   python -m pomodoro --music-folder chosic/lofi
+   pomodoro
    ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -76,28 +76,46 @@ pip install -e .
 
 ## Getting Started
 
-### Downloading Free Music
+### Optional script dependencies
 
-The project includes a script to download free lo-fi music from [Chosic](https://www.chosic.com). You can use it to build your own playlist.
+The helper scripts each have their own dependencies beyond the core timer. Install only what you need:
 
-**Note:** The scrape script requires additional dependencies. Install them with:
+| Script | Purpose | Install |
+|--------|---------|---------|
+| `scripts/scrape_songs.py` | Download lo-fi tracks from Chosic | `pip install -e ".[scrape]"` |
+| `scripts/scrape_fma.py` | Download tracks from Free Music Archive | `pip install -e ".[scrape]"` |
+| `scripts/download_youtube.py` | Download audio from YouTube | `pip install -e ".[youtube]"` + `brew install ffmpeg` |
+| `scripts/fix_id3_tags.py` | Strip empty ID3 frames to silence pygame warnings | `pip install -e ".[id3]"` |
+
+To install all optional dependencies at once:
 
 ```bash
-pip install requests beautifulsoup4
+pip install -e ".[scripts]"
 ```
 
-Then you can use the script:
+### Downloading Free Music
+
+The project includes scripts to build your playlist from free sources.
+
+**From Chosic** (lo-fi, no login required):
 
 ```bash
-# Download lo-fi tracks (default style)
 python scripts/scrape_songs.py
 ```
 
-The script will:
-- Download MP3 files from Chosic's free music library
-- Save them to `chosic/{style}/` by default (e.g., `chosic/lofi/`)
-- Remember what it has already downloaded (so you can re-run it safely)
-- Use respectful crawling with delays between requests
+**From Free Music Archive** (35 000+ lo-fi tracks, no login required):
+
+```bash
+python scripts/scrape_fma.py
+```
+
+**From YouTube** (add URLs to `youtube_links.txt` first):
+
+```bash
+python scripts/download_youtube.py
+```
+
+All scripts save tracks directly to `pomodoro/default-playlist/` and remember what was already downloaded so re-runs are safe.
 
 **Note:** You can also use any folder containing `.mp3`, `.wav`, or `.ogg` files as your music source. Simply point the timer to your folder using the `--music-folder` option.
 

--- a/docs/plans/elevenlabs-music-generation.md
+++ b/docs/plans/elevenlabs-music-generation.md
@@ -1,0 +1,211 @@
+# ElevenLabs Music Generation Support Plan
+
+## Goal
+
+Add optional ElevenLabs music generation support to the CLI Pomodoro app so users can generate focus-friendly music tracks from prompts and play them during work sessions alongside the existing bundled or folder-based playlist behavior.
+
+The first implementation should be conservative: generate audio files into a local cache/output folder, then feed those files into the existing `pygame` playlist flow. This keeps live timer playback reliable and avoids coupling the Pomodoro loop directly to network latency or API failures.
+
+## Current Project Context
+
+- The app is currently implemented in `pomodoro/__main__.py`.
+- Music playback is local-file based through `pygame.mixer.music`.
+- Work music is loaded by `load_music_files()` from either `--music-folder` or the bundled default playlist.
+- The music player runs in a daemon thread via `music_player_loop()` and accepts skip, pause, and ignore commands through queues.
+- Ignored songs are stored as local paths in `.ignored_songs`.
+- There are no automated tests or linting configs today; `CLAUDE.md` recommends manual validation with short timers such as `pomodoro --work 1 --short 1`.
+
+## External API Notes
+
+Relevant ElevenLabs docs checked while preparing this plan:
+
+- Compose music endpoint: https://elevenlabs.io/docs/api-reference/music/compose
+- Stream music endpoint: https://elevenlabs.io/docs/api-reference/music/stream
+- Python SDK repository: https://github.com/elevenlabs/elevenlabs-python
+- Eleven Music help article: https://help.elevenlabs.io/hc/en-us/articles/37780368848785-What-is-Eleven-Music
+
+Important constraints to account for:
+
+- The SDK package is `elevenlabs`.
+- The generated music model is currently `music_v1`.
+- Prompt-based generation accepts `prompt`, `music_length_ms`, `model_id`, and `force_instrumental`.
+- `music_length_ms` must be between 10,000 and 300,000 milliseconds.
+- The default generated output format is MP3 at `mp3_44100_128`.
+- API access requires an ElevenLabs API key, expected as `ELEVENLABS_API_KEY`.
+- Music API access may require a paid ElevenLabs plan.
+
+## Proposed UX
+
+Add CLI options that are explicit and opt-in:
+
+| Option | Purpose |
+| --- | --- |
+| `--elevenlabs-generate` | Enable ElevenLabs generation before the Pomodoro session starts. |
+| `--elevenlabs-prompt TEXT` | Prompt used for generation. Default can be a focus-oriented lo-fi prompt. |
+| `--elevenlabs-track-count N` | Number of tracks to generate before starting. Default: `1`. |
+| `--elevenlabs-length SEC` | Track duration in seconds. Clamp or validate to 10-300. Default: `300` or work duration capped to 300. |
+| `--elevenlabs-output-dir PATH` | Where generated tracks are saved. Default: `playlists/elevenlabs` or `.pomodoro/elevenlabs`. |
+| `--elevenlabs-force-instrumental` | Pass `force_instrumental=True`; default should be true for focus use. |
+| `--elevenlabs-use-cache` | Reuse existing generated tracks for the same prompt/settings before generating new ones. Default: true. |
+
+The first version should avoid streaming playback. Generation should happen before the timer starts, with clear terminal progress and errors. If generation fails, the app should fall back to the default playlist or `--music-folder` unless the user requested ElevenLabs-only behavior in a later option.
+
+Example target usage:
+
+```bash
+ELEVENLABS_API_KEY=... pomodoro \
+  --elevenlabs-generate \
+  --elevenlabs-prompt "Generate a calm instrumental lofi song for studying and concentration" \
+  --elevenlabs-track-count 2 \
+  --elevenlabs-length 180
+```
+
+## Implementation Strategy
+
+### 1. Add dependency
+
+Add `elevenlabs` to project dependencies in `pyproject.toml` and `requirements.txt`.
+
+Keep import failures user-friendly:
+
+- Do not import the SDK at module import time if ElevenLabs generation is disabled.
+- Import it inside the generation function.
+- If the dependency is missing, print an actionable message and continue with local music fallback.
+
+### 2. Add generation helpers
+
+Create helper functions in `pomodoro/__main__.py` first, since the app is currently single-file:
+
+- `validate_elevenlabs_length(seconds: int) -> int`
+- `get_elevenlabs_output_dir(path: str | None) -> str`
+- `build_elevenlabs_filename(prompt, length, model, index) -> str`
+- `generate_elevenlabs_tracks(...) -> list[str]`
+
+The generation helper should:
+
+1. Read `ELEVENLABS_API_KEY` from the environment.
+2. Validate that the key exists before attempting generation.
+3. Create the output directory if needed.
+4. Call:
+
+   ```python
+   from elevenlabs.client import ElevenLabs
+
+   client = ElevenLabs(api_key=os.getenv("ELEVENLABS_API_KEY"))
+   audio = client.music.compose(
+       prompt=prompt,
+       music_length_ms=length_seconds * 1000,
+       model_id="music_v1",
+       force_instrumental=force_instrumental,
+   )
+   ```
+
+5. Write the returned audio bytes or byte iterator to an `.mp3` file.
+6. Return generated file paths that can be appended to the existing playlist.
+
+The exact write logic needs to handle SDK return type defensively:
+
+- If the response is `bytes`, write it directly.
+- If it is an iterable of `bytes`, stream chunks into the file.
+- If the SDK exposes a response object with `.data`, write `.data`.
+
+### 3. Cache generated tracks
+
+Avoid accidental repeated paid generations:
+
+- Derive a stable hash from prompt, length, model, instrumental flag, and output format.
+- Store files as:
+
+  ```text
+  playlists/elevenlabs/<hash>-001.mp3
+  playlists/elevenlabs/<hash>-002.mp3
+  ```
+
+- When `--elevenlabs-use-cache` is enabled, reuse matching files before generating more.
+- Print whether a track is reused or newly generated.
+
+This should be the default because generation has credit cost and network latency.
+
+### 4. Wire generated tracks into playback
+
+Recommended first behavior:
+
+- Load existing playlist exactly as today.
+- If `--elevenlabs-generate` is set, generate or reuse tracks.
+- Prepend generated tracks to the playlist so users hear generated music first.
+- If no local tracks exist but generated tracks exist, run solely on generated tracks.
+- If generation fails and local tracks exist, continue with local tracks.
+- If both generation and local loading fail, keep the current "running without work music" behavior.
+
+This limits changes to the current playback thread and keeps skip/pause/ignore working because generated tracks are normal local files.
+
+### 5. Handle ignore behavior
+
+Generated files should work with the existing ignore system because `.ignored_songs` stores file paths.
+
+Decision to make during implementation:
+
+- Keep ignored generated files on disk, just filtered out by `.ignored_songs`.
+- Do not delete them automatically, because a generated file may cost credits and the user may want it later.
+
+### 6. Error handling
+
+Expected failures:
+
+- Missing `ELEVENLABS_API_KEY`.
+- Missing `elevenlabs` dependency.
+- Invalid generation length.
+- API authentication or plan error.
+- API validation error for prompt or duration.
+- Network failure.
+- File write failure.
+
+Behavior:
+
+- Print concise warnings.
+- Never crash a Pomodoro session if fallback local music is available.
+- Use `parser.error(...)` only for invalid CLI input such as out-of-range length.
+- Do not print API keys or full sensitive headers.
+
+### 7. Documentation updates
+
+Update `README.md` after implementation with:
+
+- Setup instructions for `ELEVENLABS_API_KEY`.
+- Install note for the `elevenlabs` dependency.
+- CLI examples.
+- A clear note that API generation can consume ElevenLabs credits and may require a paid plan.
+- A recommendation to use instrumental prompts for focus sessions.
+
+Update `CLAUDE.md` with new CLI flags and manual testing commands.
+
+### 8. Manual validation
+
+Because the repo has no automated tests today, validate manually:
+
+```bash
+pomodoro --work 1 --short 1 --cycles 1 --no-work-music
+pomodoro --work 1 --short 1 --cycles 1 --music-folder playlists/elevenlabs
+ELEVENLABS_API_KEY=... pomodoro --elevenlabs-generate --elevenlabs-length 10 --work 1 --short 1 --cycles 1
+```
+
+Also validate failure modes:
+
+```bash
+unset ELEVENLABS_API_KEY
+pomodoro --elevenlabs-generate --elevenlabs-length 10 --work 1 --short 1 --cycles 1
+pomodoro --elevenlabs-generate --elevenlabs-length 9
+pomodoro --elevenlabs-generate --elevenlabs-length 301
+```
+
+## Open Questions
+
+- Should generated tracks be prepended to the existing playlist, replace it, or be selected by a separate `--music-source elevenlabs` option?
+- Should the default output directory be committed-friendly `playlists/elevenlabs` or user-local `.pomodoro/elevenlabs`?
+- Should generation happen synchronously before the session starts, or should a later version generate the next track in the background while the current track plays?
+- Should we expose ElevenLabs `output_format` immediately, or keep the first version MP3-only to match `pygame` and simplify validation?
+- Should prompts be saved in a small metadata JSON next to each generated track for traceability?
+
+## Recommended First Cut
+
+Implement the file-cache approach with synchronous pre-session generation, generated tracks prepended to the playlist, MP3-only output, `force_instrumental=True` by default, and local fallback on API failure. This gives users the feature with minimal disruption to the existing timer and playback code.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -1,0 +1,165 @@
+# Scripts Reference
+
+Helper scripts for downloading and maintaining your music playlist.
+All scripts save to `pomodoro/default-playlist/` by default and track
+what's already been downloaded so re-runs are safe.
+
+---
+
+## scrape_songs.py
+
+Downloads free lo-fi MP3s from [Chosic](https://www.chosic.com).
+
+**Requires:** `uv pip install -e ".[scrape]"`
+
+```
+usage: scrape_songs.py [-h] [-s STYLE] [-o OUT] [--dry-run]
+
+options:
+  -s, --style STYLE   Music style/tag to scrape (default: lofi)
+  -o, --out OUT       Root output directory (default: ./chosic)
+  --dry-run           List tracks without downloading
+```
+
+**Examples:**
+
+```bash
+# Download lo-fi tracks into the default playlist
+python scripts/scrape_songs.py -o pomodoro/default-playlist
+
+# Preview what would be downloaded
+python scripts/scrape_songs.py --dry-run
+
+# Download a different style
+python scripts/scrape_songs.py -s ambient -o pomodoro/default-playlist
+```
+
+**Notes:**
+- State file: `.downloaded_ids.txt` inside the output folder
+- Crawls all pages until none remain; uses a 2-second delay between requests
+
+---
+
+## scrape_fma.py
+
+Downloads free lo-fi MP3s from [Free Music Archive](https://freemusicarchive.org) (35 000+ tracks, no login required).
+
+**Requires:** `uv pip install -e ".[scrape]"`
+
+```
+usage: scrape_fma.py [-h] [-g GENRE] [-o OUT] [--dry-run] [--max-pages N]
+
+options:
+  -g, --genre GENRE     FMA genre slug to scrape (default: Lo-fi)
+  -o, --out OUT         Output directory (default: pomodoro/default-playlist)
+  --dry-run             List tracks without downloading
+  --max-pages N         Maximum number of pages to crawl (default: all)
+```
+
+**Examples:**
+
+```bash
+# Download Lo-fi genre
+python scripts/scrape_fma.py
+
+# Download a different genre
+python scripts/scrape_fma.py -g Lo-fi-Instrumental
+python scripts/scrape_fma.py -g Ambient
+python scripts/scrape_fma.py -g Chillwave
+
+# Limit to the first 10 pages (≈200 tracks)
+python scripts/scrape_fma.py --max-pages 10
+
+# Preview without downloading
+python scripts/scrape_fma.py --dry-run --max-pages 5
+```
+
+**Notes:**
+- State file: `.fma_downloaded_ids.txt` inside the output folder
+- Uses the `/stream/` endpoint — no login required
+- 2-second delay between requests
+
+---
+
+## download_youtube.py
+
+Downloads audio from YouTube as 192 kbps MP3s using [yt-dlp](https://github.com/yt-dlp/yt-dlp).
+Supports individual videos, playlists, and channels.
+
+**Requires:** `uv pip install -e ".[youtube]"` and `brew install ffmpeg`
+
+```
+usage: download_youtube.py [-h] [-f FILE] [-o OUT] [--dry-run]
+
+options:
+  -f, --file FILE   Text file with YouTube URLs, one per line
+                    (default: youtube_links.txt)
+  -o, --out OUT     Output directory (default: pomodoro/default-playlist)
+  --dry-run         Resolve and list tracks without downloading
+```
+
+**Link file format (`youtube_links.txt`):**
+
+```
+# Lines starting with '#' are ignored, as are blank lines.
+# Supports individual videos, playlists (?list=...), and channels.
+
+https://www.youtube.com/watch?v=5qap5aO4i9A
+https://www.youtube.com/playlist?list=PLofht4PTcKYnaH8w5olJCI-wUTuSO3ZAL
+```
+
+**Examples:**
+
+```bash
+# Download everything in youtube_links.txt
+python scripts/download_youtube.py
+
+# Use a different links file
+python scripts/download_youtube.py -f my_playlist.txt
+
+# Preview what would be downloaded
+python scripts/download_youtube.py --dry-run
+
+# Download to a custom folder
+python scripts/download_youtube.py -o /path/to/music
+```
+
+**Notes:**
+- State file: `.yt_downloaded_ids.txt` inside the output folder
+- Filenames follow the pattern `Artist - Title [videoID].mp3`
+
+---
+
+## fix_id3_tags.py
+
+Strips empty COMM/USLT ID3 frames from MP3 files to silence the pygame/libmpg123 warning:
+`[src/libmpg123/id3.c:process_comment():584] error: No comment text / valid description?`
+
+Only empty frames are removed; real lyrics and meaningful comments are preserved.
+
+**Requires:** `uv pip install -e ".[id3]"`
+
+```
+usage: fix_id3_tags.py [-h] [-d DIR] [--dry-run]
+
+options:
+  -d, --dir DIR   Directory to scan (default: pomodoro/default-playlist)
+  --dry-run       Report files that need fixing without modifying them
+```
+
+**Examples:**
+
+```bash
+# Fix all tracks in the default playlist
+python scripts/fix_id3_tags.py
+
+# Preview which files would be changed
+python scripts/fix_id3_tags.py --dry-run
+
+# Fix a custom folder
+python scripts/fix_id3_tags.py -d /path/to/music
+```
+
+**Notes:**
+- Scans subdirectories recursively
+- Only removes frames where both `text` and `description` are empty

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -90,12 +90,16 @@ Supports individual videos, playlists, and channels.
 
 ```
 usage: download_youtube.py [-h] [-f FILE] [-o OUT] [--dry-run]
+                           [--max-size MB] [--timeout SECONDS]
 
 options:
-  -f, --file FILE   Text file with YouTube URLs, one per line
-                    (default: youtube_links.txt)
-  -o, --out OUT     Output directory (default: pomodoro/default-playlist)
-  --dry-run         Resolve and list tracks without downloading
+  -f, --file FILE       Text file with YouTube URLs, one per line
+                        (default: youtube_links.txt)
+  -o, --out OUT         Output directory (default: pomodoro/default-playlist)
+  --dry-run             Resolve and list tracks without downloading
+  --max-size MB         Skip videos whose estimated size exceeds this value
+                        in MB (default: 100). Useful to avoid live streams.
+  --timeout SECONDS     Per-download socket timeout in seconds (default: 120)
 ```
 
 **Link file format (`youtube_links.txt`):**
@@ -127,6 +131,8 @@ python scripts/download_youtube.py -o /path/to/music
 **Notes:**
 - State file: `.yt_downloaded_ids.txt` inside the output folder
 - Filenames follow the pattern `Artist - Title [videoID].mp3`
+- Live streams are detected and skipped automatically
+- Use `--max-size` to guard against unexpectedly large files (live radio, mixes)
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,16 @@ dependencies = [
     "psutil>=5.9.0",
 ]
 
+[project.optional-dependencies]
+# scripts/scrape_songs.py and scripts/scrape_fma.py
+scrape = ["requests", "beautifulsoup4"]
+# scripts/download_youtube.py (also requires ffmpeg system binary)
+youtube = ["yt-dlp"]
+# scripts/fix_id3_tags.py
+id3 = ["eyed3"]
+# all optional script deps at once
+scripts = ["requests", "beautifulsoup4", "yt-dlp", "eyed3"]
+
 [project.urls]
 Homepage = "https://github.com/WittmannF/lofi-pomodoro"
 Repository = "https://github.com/WittmannF/lofi-pomodoro.git"

--- a/scripts/download_youtube.py
+++ b/scripts/download_youtube.py
@@ -5,6 +5,7 @@ Download audio from YouTube links as MP3s using yt-dlp.
 Reads a plain-text file with one YouTube URL per line (videos, playlists,
 or channels). Lines starting with '#' and blank lines are ignored.
 Already-downloaded IDs are tracked in a state file so re-runs are safe.
+Live streams and videos exceeding the size limit are skipped automatically.
 
 Usage
 -----
@@ -12,6 +13,8 @@ $ python scripts/download_youtube.py                        # uses youtube_links
 $ python scripts/download_youtube.py -f my_links.txt        # custom links file
 $ python scripts/download_youtube.py -o /path/to/music      # custom output folder
 $ python scripts/download_youtube.py --dry-run              # list without downloading
+$ python scripts/download_youtube.py --max-size 50          # skip files over 50 MB
+$ python scripts/download_youtube.py --timeout 300          # per-download timeout (s)
 """
 
 from __future__ import annotations
@@ -32,6 +35,8 @@ except ImportError:
 
 STATE_FILE = ".yt_downloaded_ids.txt"
 DEFAULT_LINKS_FILE = "youtube_links.txt"
+DEFAULT_MAX_SIZE_MB = 100   # skip anything larger (live streams are typically huge)
+DEFAULT_TIMEOUT_S = 120     # per-download socket timeout in seconds
 
 
 def load_links(path: str) -> List[str]:
@@ -60,27 +65,34 @@ def mark_done(state_path: str, video_id: str) -> None:
 
 
 def resolve_ids(url: str) -> List[dict]:
-    """Return list of {id, title, url} for all videos reachable from url."""
+    """Return list of {id, title, url, is_live, filesize_mb} for all videos reachable from url."""
     opts = {
         "quiet": True,
         "no_warnings": True,
-        "extract_flat": True,  # don't download, just enumerate
+        "extract_flat": False,  # full info needed to detect live streams and size
         "skip_download": True,
     }
     with yt_dlp.YoutubeDL(opts) as ydl:
         info = ydl.extract_info(url, download=False)
     if info is None:
         return []
+
+    def _entry(e: dict) -> dict:
+        filesize = e.get("filesize") or e.get("filesize_approx") or 0
+        return {
+            "id": e["id"],
+            "title": e.get("title", e["id"]),
+            "url": e.get("webpage_url") or e.get("url") or url,
+            "is_live": bool(e.get("is_live") or e.get("was_live")),
+            "filesize_mb": filesize / (1024 * 1024),
+        }
+
     if info.get("_type") == "playlist":
-        return [
-            {"id": e["id"], "title": e.get("title", e["id"]), "url": e["url"]}
-            for e in (info.get("entries") or [])
-            if e and e.get("id")
-        ]
-    return [{"id": info["id"], "title": info.get("title", info["id"]), "url": url}]
+        return [_entry(e) for e in (info.get("entries") or []) if e and e.get("id")]
+    return [_entry(info)]
 
 
-def download_audio(url: str, out_dir: str) -> None:
+def download_audio(url: str, out_dir: str, timeout_s: int) -> None:
     opts = {
         "format": "bestaudio/best",
         "outtmpl": os.path.join(out_dir, "%(uploader)s - %(title)s [%(id)s].%(ext)s"),
@@ -91,6 +103,7 @@ def download_audio(url: str, out_dir: str) -> None:
         }],
         "quiet": True,
         "no_warnings": True,
+        "socket_timeout": timeout_s,
     }
     with yt_dlp.YoutubeDL(opts) as ydl:
         ydl.download([url])
@@ -118,6 +131,20 @@ def main() -> None:
         action="store_true",
         help="Resolve and list tracks without downloading",
     )
+    parser.add_argument(
+        "--max-size",
+        type=float,
+        default=DEFAULT_MAX_SIZE_MB,
+        metavar="MB",
+        help=f"Skip videos whose estimated size exceeds this value in MB (default: {DEFAULT_MAX_SIZE_MB})",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT_S,
+        metavar="SECONDS",
+        help=f"Per-download socket timeout in seconds (default: {DEFAULT_TIMEOUT_S})",
+    )
     args = parser.parse_args()
 
     os.makedirs(args.out, exist_ok=True)
@@ -127,7 +154,7 @@ def main() -> None:
 
     print(f"[+] Loaded {len(links)} URL(s) from {args.file}")
 
-    total_queued = total_skipped = total_ok = total_fail = 0
+    total_queued = total_skipped = total_ok = total_fail = total_ignored = 0
 
     for url in links:
         print(f"\n[>] {url}", flush=True)
@@ -147,13 +174,25 @@ def main() -> None:
                 print(f"  ~ skip (already downloaded): {title}")
                 continue
 
-            print(f"  • {title}", flush=True)
+            if entry["is_live"]:
+                total_ignored += 1
+                print(f"  ~ skip (live stream): {title}")
+                continue
+
+            size_mb = entry["filesize_mb"]
+            if size_mb > args.max_size:
+                total_ignored += 1
+                print(f"  ~ skip (too large: {size_mb:.0f} MB > {args.max_size:.0f} MB): {title}")
+                continue
+
+            size_hint = f" (~{size_mb:.0f} MB)" if size_mb > 0 else ""
+            print(f"  • {title}{size_hint}", flush=True)
 
             if args.dry_run:
                 continue
 
             try:
-                download_audio(entry["url"], args.out)
+                download_audio(entry["url"], args.out, args.timeout)
                 mark_done(state_path, vid_id)
                 total_ok += 1
             except Exception as exc:
@@ -161,9 +200,9 @@ def main() -> None:
                 total_fail += 1
 
     if args.dry_run:
-        print(f"\n[+] {total_queued} track(s) found ({total_skipped} already downloaded)")
+        print(f"\n[+] {total_queued} track(s) found ({total_skipped} already downloaded, {total_ignored} would be skipped)")
     else:
-        print(f"\n[+] {total_ok} downloaded, {total_skipped} skipped, {total_fail} failed")
+        print(f"\n[+] {total_ok} downloaded, {total_skipped} skipped, {total_ignored} ignored, {total_fail} failed")
 
 
 if __name__ == "__main__":

--- a/scripts/download_youtube.py
+++ b/scripts/download_youtube.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+Download audio from YouTube links as MP3s using yt-dlp.
+
+Reads a plain-text file with one YouTube URL per line (videos, playlists,
+or channels). Lines starting with '#' and blank lines are ignored.
+Already-downloaded IDs are tracked in a state file so re-runs are safe.
+
+Usage
+-----
+$ python scripts/download_youtube.py                        # uses youtube_links.txt
+$ python scripts/download_youtube.py -f my_links.txt        # custom links file
+$ python scripts/download_youtube.py -o /path/to/music      # custom output folder
+$ python scripts/download_youtube.py --dry-run              # list without downloading
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import List, Set
+
+try:
+    import yt_dlp
+except ImportError:
+    print(
+        "yt-dlp not installed. Run `pip install yt-dlp` (or `uv pip install yt-dlp`).",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+STATE_FILE = ".yt_downloaded_ids.txt"
+DEFAULT_LINKS_FILE = "youtube_links.txt"
+
+
+def load_links(path: str) -> List[str]:
+    if not os.path.exists(path):
+        print(f"[!] Links file not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    links = []
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line and not line.startswith("#"):
+                links.append(line)
+    return links
+
+
+def load_done(state_path: str) -> Set[str]:
+    if not os.path.exists(state_path):
+        return set()
+    with open(state_path, encoding="utf-8") as fh:
+        return {line.strip() for line in fh if line.strip()}
+
+
+def mark_done(state_path: str, video_id: str) -> None:
+    with open(state_path, "a", encoding="utf-8") as fh:
+        fh.write(video_id + "\n")
+
+
+def resolve_ids(url: str) -> List[dict]:
+    """Return list of {id, title, url} for all videos reachable from url."""
+    opts = {
+        "quiet": True,
+        "no_warnings": True,
+        "extract_flat": True,  # don't download, just enumerate
+        "skip_download": True,
+    }
+    with yt_dlp.YoutubeDL(opts) as ydl:
+        info = ydl.extract_info(url, download=False)
+    if info is None:
+        return []
+    if info.get("_type") == "playlist":
+        return [
+            {"id": e["id"], "title": e.get("title", e["id"]), "url": e["url"]}
+            for e in (info.get("entries") or [])
+            if e and e.get("id")
+        ]
+    return [{"id": info["id"], "title": info.get("title", info["id"]), "url": url}]
+
+
+def download_audio(url: str, out_dir: str) -> None:
+    opts = {
+        "format": "bestaudio/best",
+        "outtmpl": os.path.join(out_dir, "%(uploader)s - %(title)s [%(id)s].%(ext)s"),
+        "postprocessors": [{
+            "key": "FFmpegExtractAudio",
+            "preferredcodec": "mp3",
+            "preferredquality": "192",
+        }],
+        "quiet": True,
+        "no_warnings": True,
+    }
+    with yt_dlp.YoutubeDL(opts) as ydl:
+        ydl.download([url])
+
+
+def main() -> None:
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    default_out = os.path.join(repo_root, "pomodoro", "default-playlist")
+
+    parser = argparse.ArgumentParser(
+        description="Download YouTube audio as MP3s into the pomodoro playlist"
+    )
+    parser.add_argument(
+        "-f", "--file",
+        default=DEFAULT_LINKS_FILE,
+        help=f"Text file with YouTube URLs, one per line (default: {DEFAULT_LINKS_FILE})",
+    )
+    parser.add_argument(
+        "-o", "--out",
+        default=default_out,
+        help=f"Output directory (default: {default_out})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Resolve and list tracks without downloading",
+    )
+    args = parser.parse_args()
+
+    os.makedirs(args.out, exist_ok=True)
+    state_path = os.path.join(args.out, STATE_FILE)
+    done = load_done(state_path)
+    links = load_links(args.file)
+
+    print(f"[+] Loaded {len(links)} URL(s) from {args.file}")
+
+    total_queued = total_skipped = total_ok = total_fail = 0
+
+    for url in links:
+        print(f"\n[>] {url}", flush=True)
+        try:
+            entries = resolve_ids(url)
+        except Exception as exc:
+            print(f"  [!] Could not resolve: {exc}", file=sys.stderr)
+            continue
+
+        for entry in entries:
+            vid_id = entry["id"]
+            title = entry["title"]
+            total_queued += 1
+
+            if vid_id in done:
+                total_skipped += 1
+                print(f"  ~ skip (already downloaded): {title}")
+                continue
+
+            print(f"  • {title}", flush=True)
+
+            if args.dry_run:
+                continue
+
+            try:
+                download_audio(entry["url"], args.out)
+                mark_done(state_path, vid_id)
+                total_ok += 1
+            except Exception as exc:
+                print(f"    [!] Failed: {exc}", file=sys.stderr)
+                total_fail += 1
+
+    if args.dry_run:
+        print(f"\n[+] {total_queued} track(s) found ({total_skipped} already downloaded)")
+    else:
+        print(f"\n[+] {total_ok} downloaded, {total_skipped} skipped, {total_fail} failed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/download_youtube.py
+++ b/scripts/download_youtube.py
@@ -21,8 +21,11 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import sys
-from typing import List, Set
+from typing import List, Optional, Set
+
+_VIDEO_ID_RE = re.compile(r"(?:v=|youtu\.be/)([A-Za-z0-9_-]{11})")
 
 try:
     import yt_dlp
@@ -64,8 +67,22 @@ def mark_done(state_path: str, video_id: str) -> None:
         fh.write(video_id + "\n")
 
 
-def resolve_ids(url: str) -> List[dict]:
-    """Return list of {id, title, url, is_live, filesize_mb} for all videos reachable from url."""
+def _video_id_from_url(url: str) -> Optional[str]:
+    """Extract the 11-char video ID from a plain video URL without a network call."""
+    m = _VIDEO_ID_RE.search(url)
+    return m.group(1) if m else None
+
+
+def resolve_ids(url: str, done: Set[str]) -> List[dict]:
+    """Return list of {id, title, url, is_live, filesize_mb} for all videos reachable from url.
+
+    For plain video URLs whose ID is already in *done*, skip the network call entirely.
+    """
+    # Fast path: single video URL that was already downloaded
+    vid_id = _video_id_from_url(url)
+    if vid_id and vid_id in done:
+        return [{"id": vid_id, "title": vid_id, "url": url, "is_live": False, "filesize_mb": 0, "_already_done": True}]
+
     opts = {
         "quiet": True,
         "no_warnings": True,
@@ -159,7 +176,7 @@ def main() -> None:
     for url in links:
         print(f"\n[>] {url}", flush=True)
         try:
-            entries = resolve_ids(url)
+            entries = resolve_ids(url, done)
         except Exception as exc:
             print(f"  [!] Could not resolve: {exc}", file=sys.stderr)
             continue
@@ -169,7 +186,7 @@ def main() -> None:
             title = entry["title"]
             total_queued += 1
 
-            if vid_id in done:
+            if vid_id in done or entry.get("_already_done"):
                 total_skipped += 1
                 print(f"  ~ skip (already downloaded): {title}")
                 continue

--- a/youtube_links.txt
+++ b/youtube_links.txt
@@ -1,0 +1,7 @@
+# Add YouTube URLs here — one per line.
+# Supports individual videos, playlists (?list=...), and channels.
+# Lines starting with '#' are ignored.
+
+# Example:
+# https://www.youtube.com/watch?v=5qap5aO4i9A
+# https://www.youtube.com/playlist?list=PLofht4PTcKYnaH8w5olJCI-wUTuSO3ZAL


### PR DESCRIPTION
## Summary

- New `scripts/download_youtube.py` — reads YouTube URLs from `youtube_links.txt` (one per line, `#` comments ignored) and downloads each as a 192kbps MP3 into `pomodoro/default-playlist/` via `yt-dlp` + `ffmpeg`
- Supports individual videos, playlists (`?list=...`), and channels
- State file `.yt_downloaded_ids.txt` prevents re-downloading across runs
- `youtube_links.txt` template included — users add their own links

## Usage

```bash
# Install dependency (one-time)
uv pip install yt-dlp   # ffmpeg also required (brew install ffmpeg)

# Add URLs to youtube_links.txt, then:
python scripts/download_youtube.py

# Options
python scripts/download_youtube.py -f other_list.txt   # custom links file
python scripts/download_youtube.py -o /other/folder    # custom output dir
python scripts/download_youtube.py --dry-run           # list without downloading
```

## Test plan

- [ ] Add a YouTube video URL to `youtube_links.txt` and run the script
- [ ] Confirm MP3 appears in `pomodoro/default-playlist/`
- [ ] Re-run and confirm the track is skipped (state file working)
- [ ] Test with a playlist URL
- [ ] Run `pomodoro` and confirm the downloaded track plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)